### PR TITLE
Update due to location detection provider phasing-out their v1 API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ RUN apk add --no-cache --virtual .build-dependencies gcc linux-headers geoip-dev
   && chmod a+x /usr/bin/confd \
   && pip install gunicorn
 
-ENV VERSION=c70d40167a41f63f396545bc87bf6e2b7dbd496e
+ENV VERSION=1.0.0
 
 RUN mkdir /openvpn-monitor \
-  && wget -O - https://github.com/furlongm/openvpn-monitor/archive/${VERSION}.tar.gz | tar -C /openvpn-monitor --strip-components=1 -zxvf - \
-  && pip install /openvpn-monitor 
+  && wget -O - https://github.com/furlongm/openvpn-monitor/archive/${VERSION}.tar.gz | tar -C /openvpn-monitor --strip-components=1 -zxvf -
+COPY openvpn-monitor.conf /openvpn-monitor
+RUN pip install /openvpn-monitor
 
 RUN apk del .build-dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apk del .build-dependencies
 RUN mkdir -p /usr/share/GeoIP/ \
   && cd /usr/share/GeoIP/ \
   && wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-  && tar zxvf GeoLite2-City.tar.gz --strip-components=1 GeoLite2-City_20190101/GeoLite2-City.mmdb
+  && tar zxvf GeoLite2-City.tar.gz \
+  && mv GeoLite2-City_*/GeoLite2-City.mmdb . \
+  && rm -r GeoLite2-City_*
   # this tiny tar doesn't allow wildcards. therefore db build date is hardcoded...
   # also it does not have --no-anchored flag :/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN apk del .build-dependencies
 RUN mkdir -p /usr/share/GeoIP/ \
   && cd /usr/share/GeoIP/ \
   && wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-  && tar zxvf GeoLite2-City.tar.gz GeoLite2-City_20190101/GeoLite2-City.mmdb \		# this tiny tar doesn't allow wildcards. therefore db build date is hardcoded...
-  && mv */GeoLite2-City.mmdb GeoLite2-City.mmdb 									# also it does not have --no-anchored flag :/
+  && tar zxvf GeoLite2-City.tar.gz GeoLite2-City_20190101/GeoLite2-City.mmdb
+  # this tiny tar doesn't allow wildcards. therefore db build date is hardcoded...
+  # also it does not have --no-anchored flag :/
 
 RUN apk add --no-cache geoip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk del .build-dependencies
 RUN mkdir -p /usr/share/GeoIP/ \
   && cd /usr/share/GeoIP/ \
   && wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-  && tar zxvf GeoLite2-City.tar.gz GeoLite2-City_20190101/GeoLite2-City.mmdb
+  && tar zxvf GeoLite2-City.tar.gz --strip-components=1 GeoLite2-City_20190101/GeoLite2-City.mmdb
   # this tiny tar doesn't allow wildcards. therefore db build date is hardcoded...
   # also it does not have --no-anchored flag :/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apk del .build-dependencies
 
 RUN mkdir -p /usr/share/GeoIP/ \
   && cd /usr/share/GeoIP/ \
-  && wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
-  && gunzip GeoLiteCity.dat.gz \
-  && mv GeoLiteCity.dat GeoIPCity.dat
+  && wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
+  && tar zxvf GeoLite2-City.tar.gz GeoLite2-City_20190101/GeoLite2-City.mmdb \		# this tiny tar doesn't allow wildcards. therefore db build date is hardcoded...
+  && mv */GeoLite2-City.mmdb GeoLite2-City.mmdb 									# also it does not have --no-anchored flag :/
 
 RUN apk add --no-cache geoip
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ First, make sure OpenVPN is configured to open the management interface that the
 management 127.0.0.1 5555
 ```
 
+Note: if you're running OpenVPN in a container as well, allow for external connections with:
+```
+management 0.0.0.0 5555
+```
+
 All settings of OpenVPN Monitor can be dynamically configured via environment variables (thanks to confd) without having to create a new image or bind-mounting the configuration file.
 
 The environment variable are organized into two groups:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
-confd -onetime -backend env --log-level panic 
+if ! [ -e /openvpn-monitor/openvpn-monitor.conf ]; then
+  confd -onetime -backend env --log-level panic 
+fi
 
 exec "$@"

--- a/openvpn-monitor.conf
+++ b/openvpn-monitor.conf
@@ -1,0 +1,20 @@
+[openvpn-monitor]
+site=NAME
+logo="https://cdn.steemitimages.com/DQmcqPYRPigk2sLtrtKg6GhnN7diDJvyqoTRy6eVqL5bLCU/vpn.png"
+latitude=10.5
+longitude=-10.5
+maps=True
+geoip_data=/usr/share/GeoIP/GeoLite2-City.mmdb
+datetime_format=%d/%m/%Y %H:%M:%S
+
+[UDP]
+host=localhost
+port=5555
+name=UDP
+show_disconnect=True
+
+[TCP]
+host=localhost
+port=5556
+name=TCP
+show_disconnect=True

--- a/openvpn-monitor.conf
+++ b/openvpn-monitor.conf
@@ -1,5 +1,5 @@
 [openvpn-monitor]
-site=NAME
+site=Example OpenVPN Status Monitor
 logo="https://cdn.steemitimages.com/DQmcqPYRPigk2sLtrtKg6GhnN7diDJvyqoTRy6eVqL5bLCU/vpn.png"
 latitude=10.5
 longitude=-10.5


### PR DESCRIPTION
It had started as `http` → `https`, but then the company at the [other end of the line](https://dev.maxmind.com/geoip/) have removed their v1 databases all together; then current `openvpn-monitor` undergoing dockerization was not compatible with v2; then an act of configuring this new ([1.0.0](https://github.com/furlongm/openvpn-monitor/releases)) version required further modification of `Dockerfile`.
Now the only way to pass the configuration is upon `build`, which is not ideal. Those `docker run -e` envs would be welcome - see below ↓

**Todo:**
– fix `confd` templates for `openvpn-monitor 1.0.0` to parse them properly. More detail: 20009549a2109f2fad13f8bfabefd8790539bc15
– and also.. I can't remember.. idk. I'll be porting it to `armhf` now btw